### PR TITLE
Modify Makefile.am.local files to support check-local and clean-local targets.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Version 0.4.8 (david hull)
+  * modify Makefile.am to allow check-local and clean-local rules to
+    be specified in Makefile.am.local
+  * 'make clean' runs 'make clean-am'
+
 Version 0.4.7 (kenan.gillet)
   * fix make check after make clean
   * fix rebar dialyzer check

--- a/fw-pkgin/config
+++ b/fw-pkgin/config
@@ -2,7 +2,7 @@
 # variable FW_PACKAGE_DEFAULT_MAINTAINER if non-empty at init time
 
 FW_PACKAGE_NAME="fw-template-erlang-rebar"
-FW_PACKAGE_VERSION="0.4.7"
+FW_PACKAGE_VERSION="0.4.8"
 FW_PACKAGE_MAINTAINER="Anthony Molinaro <anthonym@alumni.caltech.edu>"
 FW_PACKAGE_SHORT_DESCRIPTION="Erlang template for framewerk which uses rebar to build."
 FW_PACKAGE_DESCRIPTION="`cat README`"

--- a/fw.local/template/erlang-rebar/Makefile_dot_am
+++ b/fw.local/template/erlang-rebar/Makefile_dot_am
@@ -33,12 +33,16 @@ all: .generated_app_file rebar
 	  fi ; \
 	fi
 
-check: rebar .dialyzer_ok
+.PHONY: check-local clean-local
+
+check: check-local
+
+check-local:: rebar .dialyzer_ok
 	if test -z "$(NO_EUNIT)" ; then \
 	  FW_REBAR_BUILD=1 ./rebar $(REBAR_OPTS) compile eunit ; \
 	fi
 
-clean: rebar
+clean: rebar clean-am clean-local
 	@rm -f .dialyzer_ok
 	FW_REBAR_BUILD=1 ./rebar $(REBAR_OPTS) clean
 
@@ -85,3 +89,5 @@ maintainer-clean-local::
 	  fi ; \
 	done
 	@if test -d ebin ; then rm -rf ebin ; fi
+
+clean-local::


### PR DESCRIPTION
The previous definitions in Makefile_dot_am made it difficult to add
to the check and clean targets.  Now they can be specified in the
Makefile.am.local and double-colon check-local and clean-local rules.

Fix the clean target to remove the $(CLEANFILES).